### PR TITLE
Remove forget

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -146,8 +146,6 @@ impl<T> VP9Decoder<T> {
     /// It matches a call to `vpx_codec_get_frame`.
     pub fn get_frame(&mut self) -> Option<(Frame, Option<Box<T>>)> {
         let img = unsafe { vpx_codec_get_frame(&mut self.ctx, &mut self.iter) };
-        mem::forget(img);
-
         if img.is_null() {
             None
         } else {


### PR DESCRIPTION
Forget in copy values leads to no effect. From running clippy on the project:

```
error: calls to `std::mem::forget` with a value that implements Copy. Forgetting a copy leaves the original intact.
   --> src/decoder.rs:149:9
    |
149 |         mem::forget(img);
    |         ^^^^^^^^^^^^^^^^
    |
```

As the code worked without the `mem::forget` I simply removed it