### PR TITLE
Set edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libvpx"
 version = "0.1.1"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
+edition = "2018"
 license = "MIT"
 description = "libvpx bindings"
 repository = "https://github.com/rust-av/vpx-rs"

--- a/vpx-sys/Cargo.toml
+++ b/vpx-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vpx-sys"
 version = "0.1.1"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
+edition = "2018"
 license = "MIT"
 description = "FFI bindings to vpx"
 repository = "https://github.com/rust-av/vpx-rs"


### PR DESCRIPTION
Noticed the opus crate was still pre-2018 and realized I forgot to bump it here too. Apparently no code changes are necessary.