### PR TITLE
Fix undefined behavior in `VP9Decoder::decode()`

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -130,7 +130,9 @@ impl<T> VP9Decoder<T> {
         match ret {
             VPX_CODEC_OK => Ok(()),
             _ => {
-                let _ = unsafe { Box::from_raw(priv_data) };
+                if !priv_data.is_null() {
+                    let _ = unsafe { Box::from_raw(priv_data) };
+                }
                 Err(ret)
             }
         }


### PR DESCRIPTION
In `VP9Decoder::decode()`, if `vpx_codec_decode()` fails and `private` is `None`, we attempt to construct a `Box` via `Box::from_raw()` from a NULL pointer, which is undefined behavior.